### PR TITLE
Add Rust-backed Python testing framework base

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fastest"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "fastest"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.20.0", features = ["extension-module"] }
+
+[package.metadata.maturin]
+name = "_fastest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Base image for building the fastest project
+FROM python:3.11-slim AS build
+
+# Install Rust and maturin
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential curl \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && /root/.cargo/bin/cargo install --locked maturin \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+WORKDIR /usr/src/fastest
+
+COPY . .
+RUN maturin build --release --manylinux off
+
+FROM python:3.11-slim
+
+COPY --from=build /usr/src/fastest/target/wheels/*.whl /tmp/
+RUN pip install /tmp/fastest-*.whl && rm -rf /tmp/fastest-*.whl
+
+ENTRYPOINT ["fastest"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# fastest
+
+`fastest` is a minimal rust-powered Python testing framework. This repository
+contains the initial skeleton of the tool using [pyo3](https://pyo3.rs/) and
+[maturin](https://github.com/PyO3/maturin) to build a Python extension module
+that exposes a simple CLI.
+
+The project is inspired by tools like `uv` and `ruff`, aiming to eventually
+provide blazing fast test execution for Python projects.
+
+## Building
+
+To build the Python package, install `maturin` and run:
+
+```bash
+maturin develop
+```
+
+This will compile the Rust extension and install the `fastest` package into
+your current environment.
+
+## Usage
+
+```bash
+fastest
+```
+
+Currently the implementation is a stub that prints a message.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["maturin>=1.4,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "fastest"
+version = "0.1.0"
+authors = [{ name = "Your Name", email = "you@example.com" }]
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.8"
+description = "A rust-powered python testing framework"
+
+[tool.maturin]
+bindings = "pyo3"
+module-name = "_fastest"
+
+[project.scripts]
+fastest = "fastest.__main__:main"

--- a/python/fastest/__init__.py
+++ b/python/fastest/__init__.py
@@ -1,0 +1,4 @@
+"""fastest - Rust backed testing framework."""
+from ._fastest import run_tests
+
+__all__ = ["run_tests"]

--- a/python/fastest/__main__.py
+++ b/python/fastest/__main__.py
@@ -1,0 +1,9 @@
+from . import run_tests
+
+
+def main() -> None:
+    run_tests()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,13 @@
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn run_tests() -> PyResult<()> {
+    println!("fastest: running tests (stub)");
+    Ok(())
+}
+
+#[pymodule]
+fn fastest(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(run_tests, m)?)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- set up Rust crate with pyo3 bindings
- add minimal Python package and CLI entrypoint
- write Dockerfile to build and package the tool
- document build and usage in README

## Testing
- `cargo test` *(fails: could not download crates)*
- `pytest`