### PR TITLE
feat: phase 3 streaming output & UX polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1620,6 +1621,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+dependencies = [
+ "rustix",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,6 +1984,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2005,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2014,11 +2040,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2034,6 +2077,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2044,6 +2093,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2058,10 +2113,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2076,6 +2143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2159,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2100,6 +2179,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2195,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/crates/fastest-cli/Cargo.toml
+++ b/crates/fastest-cli/Cargo.toml
@@ -30,6 +30,7 @@ glob-match = "0.2"
 # Output
 colored = "2.1"
 indicatif = "0.17"
+terminal_size = "0.4"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/fastest-cli/src/main.rs
+++ b/crates/fastest-cli/src/main.rs
@@ -20,8 +20,10 @@ use fastest_core::{
 use fastest_execution::timeout::TimeoutConfig;
 use fastest_execution::HybridExecutor;
 
-use crate::output::{format_results, print_summary, write_junit_xml, OutputFormat};
-use crate::progress::create_spinner;
+use crate::output::{
+    format_result_line, format_results, print_header, print_summary, write_junit_xml, OutputFormat,
+};
+use crate::progress::create_progress_bar;
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing
@@ -128,6 +130,14 @@ struct Cli {
     #[arg(long = "collect-only", visible_alias = "co")]
     collect_only: bool,
 
+    /// Show registered markers and exit
+    #[arg(long = "markers")]
+    show_markers: bool,
+
+    /// Show available fixtures and exit
+    #[arg(long = "fixtures")]
+    show_fixtures: bool,
+
     /// Ignore paths during collection
     #[arg(long = "ignore", action = clap::ArgAction::Append)]
     ignore_paths: Vec<String>,
@@ -180,6 +190,28 @@ fn main() -> ExitCode {
             }
         },
         None => {
+            // Handle --markers
+            if cli.show_markers {
+                match run_show_markers() {
+                    Ok(_) => return ExitCode::SUCCESS,
+                    Err(e) => {
+                        eprintln!("{}: {}", "error".red().bold(), e);
+                        return ExitCode::FAILURE;
+                    }
+                }
+            }
+
+            // Handle --fixtures
+            if cli.show_fixtures {
+                match run_show_fixtures() {
+                    Ok(_) => return ExitCode::SUCCESS,
+                    Err(e) => {
+                        eprintln!("{}: {}", "error".red().bold(), e);
+                        return ExitCode::FAILURE;
+                    }
+                }
+            }
+
             if cli.collect_only {
                 match run_discover(&cli.paths, &cli.output_format) {
                     Ok(_) => return ExitCode::SUCCESS,
@@ -224,17 +256,78 @@ fn main() -> ExitCode {
 /// Debounce interval for watch mode (milliseconds).
 const WATCH_DEBOUNCE_MS: u64 = 300;
 
+/// A parsed node-ID like `tests/test_math.py::TestCalc::test_add`.
+struct NodeId {
+    /// The file/directory path portion.
+    path: PathBuf,
+    /// Optional class name filter (e.g., "TestCalc").
+    class_filter: Option<String>,
+    /// Optional function name filter (e.g., "test_add").
+    function_filter: Option<String>,
+}
+
+/// Parse a CLI path argument, splitting on `::` for node-ID syntax.
+///
+/// Examples:
+/// - `tests/` → path only
+/// - `tests/test_math.py::test_add` → path + function
+/// - `tests/test_math.py::TestCalc::test_add` → path + class + function
+fn parse_node_id(arg: &str) -> NodeId {
+    let parts: Vec<&str> = arg.splitn(2, "::").collect();
+    if parts.len() == 1 {
+        NodeId {
+            path: PathBuf::from(arg),
+            class_filter: None,
+            function_filter: None,
+        }
+    } else {
+        let path = PathBuf::from(parts[0]);
+        let selectors: Vec<&str> = parts[1].split("::").collect();
+        match selectors.len() {
+            1 => NodeId {
+                path,
+                class_filter: None,
+                function_filter: Some(selectors[0].to_string()),
+            },
+            _ => NodeId {
+                path,
+                class_filter: Some(selectors[0].to_string()),
+                function_filter: Some(selectors[selectors.len() - 1].to_string()),
+            },
+        }
+    }
+}
+
 /// Resolve the set of directories to search for tests.
 ///
 /// Priority: explicit CLI paths > `testpaths` from config > current directory.
 fn resolve_search_paths(paths: &[String], config: &Config) -> Vec<PathBuf> {
     if !paths.is_empty() {
-        paths.iter().map(PathBuf::from).collect()
+        // Strip :: node-ID suffixes — only use the path portion for discovery
+        paths.iter().map(|p| parse_node_id(p).path).collect()
     } else if !config.testpaths.is_empty() {
         config.testpaths.clone()
     } else {
         vec![PathBuf::from(".")]
     }
+}
+
+/// Extract node-ID filters from CLI path arguments.
+///
+/// Returns (class_filters, function_filters) from any `::` syntax in paths.
+fn extract_node_filters(paths: &[String]) -> (Vec<String>, Vec<String>) {
+    let mut class_filters = Vec::new();
+    let mut function_filters = Vec::new();
+    for p in paths {
+        let node = parse_node_id(p);
+        if let Some(c) = node.class_filter {
+            class_filters.push(c);
+        }
+        if let Some(f) = node.function_filter {
+            function_filters.push(f);
+        }
+    }
+    (class_filters, function_filters)
 }
 
 /// Inject autouse fixtures from conftest.py files into test items.
@@ -277,19 +370,150 @@ fn run_discover(paths: &[String], output_format: &str) -> anyhow::Result<()> {
             println!("{} tests discovered", tests.len());
         }
         _ => {
-            // Pretty: list each test
+            // Tree view: group by module, then class
+            let mut current_module = String::new();
+            let mut current_class: Option<String> = None;
+
             for test in &tests {
-                let location = if let Some(line) = test.line_number {
-                    format!("{}:{}", test.path.display(), line)
+                let module = test.path.display().to_string();
+
+                // Print module header on change
+                if module != current_module {
+                    if !current_module.is_empty() {
+                        println!();
+                    }
+                    println!("{}", format!("<Module {}>", module).bold());
+                    current_module = module;
+                    current_class = None;
+                }
+
+                // Print class header on change
+                if test.class_name != current_class {
+                    if let Some(ref cls) = test.class_name {
+                        println!("  {}", format!("<Class {}>", cls).bold());
+                    }
+                    current_class = test.class_name.clone();
+                }
+
+                // Print test function
+                let indent = if test.class_name.is_some() {
+                    "    "
                 } else {
-                    test.path.display().to_string()
+                    "  "
                 };
-                println!("  {} {}", location.dimmed(), test.id);
+                println!(
+                    "{}{} {}",
+                    indent,
+                    "<Function".dimmed(),
+                    format!("{}>", test.function_name).dimmed()
+                );
             }
+
             println!(
                 "\n{}",
-                format!("{} tests discovered", tests.len()).green().bold()
+                format!("{} tests collected", tests.len()).green().bold()
             );
+        }
+    }
+
+    Ok(())
+}
+
+/// Show registered markers from config.
+fn run_show_markers() -> anyhow::Result<()> {
+    let config = Config::load()?;
+
+    println!("{}", "=== registered markers (from config) ===".bold());
+
+    // Built-in markers always available
+    let builtins = [
+        ("skip", "skip the test unconditionally"),
+        ("skipif", "skip the test if condition is true"),
+        ("xfail", "mark test as expected to fail"),
+        ("parametrize", "generate multiple test cases"),
+        ("timeout", "set per-test timeout in seconds"),
+        ("usefixtures", "use fixtures without argument injection"),
+    ];
+
+    for (name, desc) in &builtins {
+        println!("  @pytest.mark.{}: {}", name.cyan().bold(), desc);
+    }
+
+    // Custom markers from config
+    if !config.markers.is_empty() {
+        println!("\n{}", "--- custom markers ---".dimmed());
+        for marker in &config.markers {
+            // Markers in config are formatted as "name: description" or just "name"
+            let (name, desc) = if let Some(idx) = marker.find(':') {
+                (&marker[..idx], marker[idx + 1..].trim())
+            } else {
+                (marker.as_str(), "")
+            };
+            if desc.is_empty() {
+                println!("  @pytest.mark.{}", name.cyan().bold());
+            } else {
+                println!("  @pytest.mark.{}: {}", name.cyan().bold(), desc);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Show available fixtures with scope info.
+fn run_show_fixtures() -> anyhow::Result<()> {
+    println!("{}", "=== available fixtures ===".bold());
+
+    // Built-in fixtures
+    let builtins = [
+        (
+            "tmp_path",
+            "function",
+            "Temporary directory unique to the test invocation",
+        ),
+        (
+            "tmp_path_factory",
+            "session",
+            "Factory for creating temp directories",
+        ),
+        ("capsys", "function", "Capture stdout/stderr writes"),
+        ("capfd", "function", "Capture file descriptor 1/2 output"),
+        (
+            "monkeypatch",
+            "function",
+            "Modify objects, dicts, or environment vars",
+        ),
+        ("caplog", "function", "Capture log records"),
+        ("request", "function", "Information about the test request"),
+    ];
+
+    println!("{}", "--- builtin ---".dimmed());
+    for (name, scope, desc) in &builtins {
+        println!(
+            "  {} [{}]\n      {}",
+            name.cyan().bold(),
+            scope.yellow(),
+            desc
+        );
+    }
+
+    // Conftest fixtures
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    if let Ok(conftest_fixtures) = discover_conftest_fixtures(&cwd) {
+        if !conftest_fixtures.is_empty() {
+            println!("\n{}", "--- from conftest.py ---".dimmed());
+            let mut fixtures: Vec<_> = conftest_fixtures.values().collect();
+            fixtures.sort_by_key(|f| &f.name);
+            for f in fixtures {
+                let autouse_tag = if f.autouse { " (autouse)" } else { "" };
+                println!(
+                    "  {} [{}]{}\n      defined in {}",
+                    f.name.cyan().bold(),
+                    format!("{}", f.scope).yellow(),
+                    autouse_tag.dimmed(),
+                    f.func_path.display().to_string().dimmed()
+                );
+            }
         }
     }
 
@@ -461,6 +685,33 @@ fn run_tests(cli: &Cli) -> anyhow::Result<bool> {
         tests
     };
 
+    // 8c. Apply node-ID filters from :: syntax in paths
+    let (class_filters, function_filters) = extract_node_filters(&cli.paths);
+    let tests = if !class_filters.is_empty() || !function_filters.is_empty() {
+        tests
+            .into_iter()
+            .filter(|t| {
+                let class_ok = class_filters.is_empty()
+                    || t.class_name
+                        .as_ref()
+                        .is_some_and(|c| class_filters.contains(c));
+                let func_ok =
+                    function_filters.is_empty() || function_filters.contains(&t.function_name);
+                // If only function filters, match function name OR class name
+                if class_filters.is_empty() {
+                    func_ok
+                        || t.class_name
+                            .as_ref()
+                            .is_some_and(|c| function_filters.contains(c))
+                } else {
+                    class_ok && func_ok
+                }
+            })
+            .collect()
+    } else {
+        tests
+    };
+
     if tests.is_empty() {
         eprintln!("{}", "no tests collected".yellow());
         plugins.shutdown_all()?;
@@ -468,10 +719,11 @@ fn run_tests(cli: &Cli) -> anyhow::Result<bool> {
     }
 
     // Print header
+    let rootdir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    print_header(&rootdir);
     eprintln!(
-        "{} {} collecting {} test{}...",
+        "{} collecting {} test{}...",
         "fastest".cyan().bold(),
-        format!("v{}", fastest_core::VERSION).dimmed(),
         tests.len(),
         if tests.len() == 1 { "" } else { "s" }
     );
@@ -510,12 +762,21 @@ fn run_tests(cli: &Cli) -> anyhow::Result<bool> {
             }
         }
         results
-    } else if !cli.no_progress && !cli.verbose {
-        // Run with spinner (execution is synchronous, results arrive in bulk)
-        let spinner = create_spinner(tests.len());
-        let results = executor.execute(&tests);
-        spinner.finish_and_clear();
-        results
+    } else if !cli.no_progress {
+        // Streaming execution with live progress bar
+        let pb = create_progress_bar(tests.len());
+        let verbose = cli.verbose;
+        executor.execute_streaming(&tests, &move |result| {
+            pb.inc(1);
+            if verbose {
+                pb.println(format_result_line(result, true));
+            }
+        })
+    } else if cli.verbose {
+        // Verbose without progress bar — stream results to stderr
+        executor.execute_streaming(&tests, &|result| {
+            eprintln!("{}", format_result_line(result, true));
+        })
     } else {
         executor.execute(&tests)
     };
@@ -792,10 +1053,11 @@ fn run_watch_cycle(cfg: &WatchConfig) -> anyhow::Result<()> {
         return Ok(());
     }
 
+    let rootdir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    print_header(&rootdir);
     eprintln!(
-        "{} {} collecting {} test{}...",
+        "{} collecting {} test{}...",
         "fastest".cyan().bold(),
-        format!("v{}", fastest_core::VERSION).dimmed(),
         tests.len(),
         if tests.len() == 1 { "" } else { "s" }
     );
@@ -833,7 +1095,14 @@ fn run_watch_cycle(cfg: &WatchConfig) -> anyhow::Result<()> {
         }
         results
     } else {
-        executor.execute(&tests)
+        let pb = create_progress_bar(tests.len());
+        let verbose = cfg.verbose;
+        executor.execute_streaming(&tests, &move |result| {
+            pb.inc(1);
+            if verbose {
+                pb.println(format_result_line(result, true));
+            }
+        })
     };
 
     // Save last-failed cache

--- a/crates/fastest-cli/src/output.rs
+++ b/crates/fastest-cli/src/output.rs
@@ -11,8 +11,15 @@ use std::time::Duration;
 use colored::Colorize;
 use fastest_core::{TestOutcome, TestResult};
 
-/// Width of separator lines in output (e.g. "=" repeated).
-const SEPARATOR_WIDTH: usize = 60;
+/// Default separator width when terminal size cannot be detected.
+const DEFAULT_WIDTH: usize = 80;
+
+/// Get the current terminal width, falling back to DEFAULT_WIDTH.
+fn term_width() -> usize {
+    terminal_size::terminal_size()
+        .map(|(w, _)| w.0 as usize)
+        .unwrap_or(DEFAULT_WIDTH)
+}
 
 /// Supported output formats.
 #[derive(Debug, Clone)]
@@ -65,87 +72,140 @@ pub fn format_results(
 /// followed by a summary line.
 fn format_pretty(results: &[TestResult], verbose: bool, tb: &str, quiet: bool) -> String {
     let mut out = String::new();
+    let width = term_width();
 
-    for result in results {
-        // In quiet mode, only show failures and errors
-        if quiet {
+    // In quiet mode with no failures, show pytest-style dot progress
+    if quiet {
+        let mut dots = String::new();
+        for result in results {
             match &result.outcome {
-                TestOutcome::Failed | TestOutcome::Error { .. } => {}
-                _ => continue,
+                TestOutcome::Passed => dots.push('.'),
+                TestOutcome::Failed => dots.push('F'),
+                TestOutcome::Skipped { .. } => dots.push('s'),
+                TestOutcome::XFailed { .. } => dots.push('x'),
+                TestOutcome::XPassed => dots.push('X'),
+                TestOutcome::Error { .. } => dots.push('E'),
             }
         }
-
-        let status = match &result.outcome {
-            TestOutcome::Passed => "PASSED".green().bold().to_string(),
-            TestOutcome::Failed => "FAILED".red().bold().to_string(),
-            TestOutcome::Skipped { .. } => "SKIPPED".yellow().bold().to_string(),
-            TestOutcome::XFailed { .. } => "XFAIL".yellow().to_string(),
-            TestOutcome::XPassed => "XPASS".yellow().bold().to_string(),
-            TestOutcome::Error { .. } => "ERROR".red().bold().to_string(),
-        };
-
-        let _ = write!(out, "{} {}", status, result.test_id);
-
-        if verbose {
-            let _ = write!(out, " ({:.3}s)", result.duration.as_secs_f64());
+        if !dots.is_empty() {
+            let _ = writeln!(out, "{}", dots);
         }
+    } else {
+        for result in results {
+            let status = match &result.outcome {
+                TestOutcome::Passed => "PASSED".green().bold().to_string(),
+                TestOutcome::Failed => "FAILED".red().bold().to_string(),
+                TestOutcome::Skipped { .. } => "SKIPPED".yellow().bold().to_string(),
+                TestOutcome::XFailed { .. } => "XFAIL".yellow().to_string(),
+                TestOutcome::XPassed => "XPASS".yellow().bold().to_string(),
+                TestOutcome::Error { .. } => "ERROR".red().bold().to_string(),
+            };
 
-        out.push('\n');
+            let _ = write!(out, "{} {}", status, result.test_id);
 
-        // Print failure details
-        if verbose {
-            if let Some(ref err) = result.error {
-                let _ = writeln!(out, "    {}", err.red());
+            if verbose {
+                let _ = write!(out, " ({:.3}s)", result.duration.as_secs_f64());
             }
-            if !result.stdout.is_empty() {
-                let _ = writeln!(out, "    --- stdout ---\n    {}", result.stdout);
-            }
-            if !result.stderr.is_empty() {
-                let _ = writeln!(out, "    --- stderr ---\n    {}", result.stderr);
-            }
-        } else if tb != "no" {
-            // In non-verbose mode, show error for failures based on --tb setting
-            match &result.outcome {
-                TestOutcome::Failed | TestOutcome::Error { .. } => {
-                    if let Some(ref err) = result.error {
-                        if tb == "short" {
-                            // Show only the last line of the traceback
-                            let last_line = err.lines().last().unwrap_or(err);
-                            let _ = writeln!(out, "    {}", last_line.red());
-                        } else {
-                            // "long" - show full traceback
-                            let _ = writeln!(out, "    {}", err.red());
+
+            out.push('\n');
+
+            // Print failure details
+            if verbose {
+                if let Some(ref err) = result.error {
+                    let _ = writeln!(out, "    {}", err.red());
+                }
+                if !result.stdout.is_empty() {
+                    let _ = writeln!(out, "    --- stdout ---\n    {}", result.stdout);
+                }
+                if !result.stderr.is_empty() {
+                    let _ = writeln!(out, "    --- stderr ---\n    {}", result.stderr);
+                }
+            } else if tb != "no" {
+                // In non-verbose mode, show error for failures based on --tb setting
+                match &result.outcome {
+                    TestOutcome::Failed | TestOutcome::Error { .. } => {
+                        if let Some(ref err) = result.error {
+                            match tb {
+                                "line" => {
+                                    // Single-line: just FAILED test_id - last error line
+                                    // (shown in the short summary instead)
+                                }
+                                "short" => {
+                                    // Show file:line reference + assertion line
+                                    let lines: Vec<&str> = err.lines().collect();
+                                    // Find the last file reference line and the assertion
+                                    let file_line = lines
+                                        .iter()
+                                        .rev()
+                                        .find(|l| l.contains("File \"") || l.contains(".py:"));
+                                    let assertion = lines.last();
+                                    if let Some(fl) = file_line {
+                                        let _ = writeln!(out, "    {}", fl.trim().red());
+                                    }
+                                    if let Some(a) = assertion {
+                                        if file_line.is_none_or(|fl| *a != *fl) {
+                                            let _ = writeln!(out, "    {}", a.trim().red());
+                                        }
+                                    }
+                                }
+                                _ => {
+                                    // "long" - show full traceback
+                                    let _ = writeln!(out, "    {}", err.red());
+                                }
+                            }
                         }
                     }
+                    _ => {}
                 }
-                _ => {}
             }
         }
     }
 
-    // Collect failures for summary section
+    // Collect failures for FAILURES section
     let failures: Vec<&TestResult> = results
         .iter()
         .filter(|r| matches!(r.outcome, TestOutcome::Failed | TestOutcome::Error { .. }))
         .collect();
 
-    if !failures.is_empty() && !quiet {
-        let _ = writeln!(out, "\n{}", "=".repeat(SEPARATOR_WIDTH));
-        let _ = write!(out, "{}", "FAILURES".red().bold());
-        out.push('\n');
-        let _ = writeln!(out, "{}", "=".repeat(SEPARATOR_WIDTH));
+    if !failures.is_empty() {
+        // Centered FAILURES header
+        let header = format!("{:=^width$}", " FAILURES ", width = width);
+        let _ = writeln!(out, "\n{}", header.red().bold());
+
         for result in &failures {
-            let _ = writeln!(out, "___ {} ___", result.test_id);
+            let test_header = format!(
+                "{:_^width$}",
+                format!(" {} ", result.test_id),
+                width = width
+            );
+            let _ = writeln!(out, "{}", test_header);
+
             if let Some(ref err) = result.error {
                 let _ = writeln!(out, "{}", err);
             }
+
+            // Show captured stdout in FAILURES section
+            if !result.stdout.is_empty() {
+                let cap_header = format!("{:-^width$}", " Captured stdout call ", width = width);
+                let _ = writeln!(out, "{}", cap_header);
+                let _ = writeln!(out, "{}", result.stdout);
+            }
+
+            // Show captured stderr in FAILURES section
+            if !result.stderr.is_empty() {
+                let cap_header = format!("{:-^width$}", " Captured stderr call ", width = width);
+                let _ = writeln!(out, "{}", cap_header);
+                let _ = writeln!(out, "{}", result.stderr);
+            }
+
             out.push('\n');
         }
     }
 
     // Short test summary info
-    if !failures.is_empty() && !quiet {
-        let _ = writeln!(out, "\n= SHORT TEST SUMMARY INFO =");
+    if !failures.is_empty() {
+        let summary_header = format!("{:=^width$}", " short test summary info ", width = width);
+        let _ = writeln!(out, "{}", summary_header.yellow());
         for result in &failures {
             let error_summary = result
                 .error
@@ -283,12 +343,27 @@ pub fn write_junit_xml(results: &[TestResult], path: &str) -> anyhow::Result<()>
     Ok(())
 }
 
+/// Print a pytest-style header line with context.
+///
+/// Example: `====== fastest v2.3.1 — rootdir: /home/user/project, platform: linux ======`
+pub fn print_header(rootdir: &Path) {
+    let width = term_width();
+    let info = format!(
+        " fastest v{} — rootdir: {}, platform: {} ",
+        fastest_core::VERSION,
+        rootdir.display(),
+        std::env::consts::OS,
+    );
+    let header = format!("{:=^width$}", info, width = width);
+    eprintln!("{}", header.bold());
+}
+
 /// Print a coloured summary line with timing.
 ///
-/// Example: "4 passed, 1 failed in 2.34s"
+/// Example: "====== 4 passed, 1 failed in 2.34s ======"
 pub fn print_summary(results: &[TestResult], duration: Duration) {
+    let width = term_width();
     let c = count_outcomes(results);
-    let total = results.len();
 
     let mut parts: Vec<String> = Vec::new();
 
@@ -318,28 +393,28 @@ pub fn print_summary(results: &[TestResult], duration: Duration) {
     };
 
     let has_failures = c.failed > 0 || c.errors > 0 || c.xpassed > 0;
-    let separator = "=".repeat(SEPARATOR_WIDTH);
-    let decoration = if has_failures {
-        separator.red().to_string()
-    } else {
-        separator.green().to_string()
-    };
 
-    // TODO: Warnings summary — collect and display pytest-style warnings here
-    // before the final decorated result line. Example:
-    //   eprintln!("{}", "= warnings summary =".yellow());
-    //   for warning in &collected_warnings {
-    //       eprintln!("  {}", warning);
-    //   }
-
-    eprintln!("{}", decoration);
-    eprintln!(
-        "{} {} in {:.2}s",
+    // Build the centered summary line: "====== N passed in 1.23s ======"
+    // We need to strip ANSI codes to compute the visual width
+    let plain_summary = strip_ansi_codes(&summary);
+    let timing = format!("in {:.2}s", duration.as_secs_f64());
+    let inner = format!(" {} {} ", plain_summary, timing);
+    let pad = width.saturating_sub(inner.len());
+    let left_pad = pad / 2;
+    let right_pad = pad - left_pad;
+    let line = format!(
+        "{} {} {} {}",
+        "=".repeat(left_pad),
         summary,
-        format!("({} total)", total).dimmed(),
-        duration.as_secs_f64()
+        timing,
+        "=".repeat(right_pad)
     );
-    eprintln!("{}", decoration);
+
+    if has_failures {
+        eprintln!("{}", line.red());
+    } else {
+        eprintln!("{}", line.green());
+    }
 }
 
 /// Print a report summary filtered by the given report characters.
@@ -421,9 +496,49 @@ pub fn print_report_summary(results: &[TestResult], report_chars: &str) {
     }
 }
 
+/// Format a single test result for live/streaming output.
+pub fn format_result_line(result: &TestResult, verbose: bool) -> String {
+    let status = match &result.outcome {
+        TestOutcome::Passed => "PASSED".green().bold().to_string(),
+        TestOutcome::Failed => "FAILED".red().bold().to_string(),
+        TestOutcome::Skipped { .. } => "SKIPPED".yellow().bold().to_string(),
+        TestOutcome::XFailed { .. } => "XFAIL".yellow().to_string(),
+        TestOutcome::XPassed => "XPASS".yellow().bold().to_string(),
+        TestOutcome::Error { .. } => "ERROR".red().bold().to_string(),
+    };
+    if verbose {
+        format!(
+            "{} {} ({:.3}s)",
+            status,
+            result.test_id,
+            result.duration.as_secs_f64()
+        )
+    } else {
+        format!("{} {}", status, result.test_id)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Strip ANSI escape codes for computing visual width.
+fn strip_ansi_codes(s: &str) -> String {
+    let mut out = String::new();
+    let mut in_escape = false;
+    for ch in s.chars() {
+        if in_escape {
+            if ch.is_ascii_alphabetic() {
+                in_escape = false;
+            }
+        } else if ch == '\x1b' {
+            in_escape = true;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
 
 /// Outcome counts for summary display.
 struct OutcomeCounts {
@@ -575,5 +690,18 @@ mod tests {
             OutputFormat::from_str_with_junit(None, Some("report.xml".into())),
             OutputFormat::JunitXml(_)
         ));
+    }
+
+    #[test]
+    fn test_strip_ansi_codes() {
+        assert_eq!(strip_ansi_codes("hello"), "hello");
+        assert_eq!(strip_ansi_codes("\x1b[32mgreen\x1b[0m"), "green");
+    }
+
+    #[test]
+    fn test_term_width_fallback() {
+        // In test environment, term_width might return default
+        let w = term_width();
+        assert!(w > 0);
     }
 }

--- a/crates/fastest-cli/src/progress.rs
+++ b/crates/fastest-cli/src/progress.rs
@@ -1,15 +1,27 @@
 //! Progress display for test execution.
 //!
-//! Uses the `indicatif` crate to show a spinner while tests run.
+//! Uses the `indicatif` crate to show a progress bar as tests complete.
 
 use indicatif::{ProgressBar, ProgressStyle};
 
-/// Create a spinner for test execution.
+/// Create a progress bar for test execution.
 ///
-/// Displays a spinning indicator with the test count while the executor runs.
-/// This is preferable to a progress bar because the hybrid executor returns
-/// all results at once rather than streaming them.
-pub fn create_spinner(total: usize) -> ProgressBar {
+/// Displays a progress bar showing `[15/100] tests running... ..F.s.`
+/// that updates as each test result arrives via the streaming callback.
+pub fn create_progress_bar(total: usize) -> ProgressBar {
+    let pb = ProgressBar::new(total as u64);
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:.green} [{pos}/{len}] {msg} [{elapsed_precise}]")
+            .unwrap_or_else(|_| ProgressStyle::default_bar()),
+    );
+    pb.set_message("running tests...");
+    pb.enable_steady_tick(std::time::Duration::from_millis(100));
+    pb
+}
+
+/// Create a simple spinner for when total count is unknown.
+#[cfg(test)]
+fn create_spinner(total: usize) -> ProgressBar {
     let pb = ProgressBar::new_spinner();
     pb.set_style(
         ProgressStyle::with_template("{spinner:.green} running {msg}")
@@ -23,6 +35,12 @@ pub fn create_spinner(total: usize) -> ProgressBar {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_create_progress_bar() {
+        let pb = create_progress_bar(100);
+        assert_eq!(pb.length(), Some(100));
+    }
 
     #[test]
     fn test_create_spinner() {

--- a/crates/fastest-execution/src/executor.rs
+++ b/crates/fastest-execution/src/executor.rs
@@ -76,6 +76,22 @@ impl HybridExecutor {
         }
     }
 
+    /// Execute tests with a callback invoked after each test completes.
+    ///
+    /// Enables live progress bars and streaming output.
+    pub fn execute_streaming(
+        &self,
+        tests: &[TestItem],
+        on_result: &(dyn Fn(&TestResult) + Send + Sync),
+    ) -> Vec<TestResult> {
+        match select_strategy(tests.len()) {
+            ExecutionStrategy::InProcess => self.inprocess.execute_with_callback(tests, on_result),
+            ExecutionStrategy::Subprocess => {
+                self.subprocess.execute_with_callback(tests, on_result)
+            }
+        }
+    }
+
     /// Access the underlying in-process executor.
     pub fn inprocess(&self) -> &InProcessExecutor {
         &self.inprocess

--- a/crates/fastest-execution/src/inprocess.rs
+++ b/crates/fastest-execution/src/inprocess.rs
@@ -38,6 +38,22 @@ impl InProcessExecutor {
         tests.iter().map(|test| self.run_single(test)).collect()
     }
 
+    /// Execute tests with a callback invoked after each test completes.
+    pub fn execute_with_callback(
+        &self,
+        tests: &[TestItem],
+        on_result: impl Fn(&TestResult),
+    ) -> Vec<TestResult> {
+        tests
+            .iter()
+            .map(|test| {
+                let result = self.run_single(test);
+                on_result(&result);
+                result
+            })
+            .collect()
+    }
+
     /// Run a single test item using the embedded Python interpreter.
     fn run_single(&self, test: &TestItem) -> TestResult {
         // Check for skip/skipif markers BEFORE execution

--- a/crates/fastest-execution/src/subprocess.rs
+++ b/crates/fastest-execution/src/subprocess.rs
@@ -278,6 +278,18 @@ impl SubprocessPool {
     /// Each worker is a persistent Python process running the worker harness.
     /// Tests are sorted by (path, class_name) to improve setup/teardown lifecycle.
     pub fn execute(&self, tests: &[TestItem]) -> Vec<TestResult> {
+        self.execute_with_callback(tests, &|_| {})
+    }
+
+    /// Execute tests with a callback invoked after each test completes.
+    ///
+    /// The callback is called from worker threads as each result arrives,
+    /// enabling live progress bars and streaming output.
+    pub fn execute_with_callback(
+        &self,
+        tests: &[TestItem],
+        on_result: &(dyn Fn(&TestResult) + Send + Sync),
+    ) -> Vec<TestResult> {
         if tests.is_empty() {
             return Vec::new();
         }
@@ -382,6 +394,7 @@ impl SubprocessPool {
                                 TestOutcome::Error { message } if message.contains("timeout")
                             );
                             if was_timeout {
+                                on_result(&result);
                                 let mut guard = results_lock.lock();
                                 guard[idx] = Some(result);
                             } else {
@@ -389,6 +402,7 @@ impl SubprocessPool {
                                 injector.push((idx, test));
                             }
                         } else {
+                            on_result(&result);
                             let mut guard = results_lock.lock();
                             guard[idx] = Some(result);
                         }


### PR DESCRIPTION
- Streaming test results: callback-based execute_with_callback on InProcessExecutor and SubprocessPool, HybridExecutor.execute_streaming for live progress updates as each test completes
- Live progress bar via indicatif [pos/len] format with elapsed timer
- Verbose mode streams results above the progress bar via pb.println
- Terminal-width-aware output: dynamic separator widths, centered FAILURES/summary headers using terminal_size crate
- Captured stdout/stderr in FAILURES section with proper headers
- --tb=short shows file:line + assertion, --tb=line minimal output
- Quiet mode shows dot progress (..F.s.)
- Platform/rootdir header line at test run start
- Node-ID path syntax: tests/test_foo.py::TestClass::test_method parses :: separators to filter by class/function name
- --markers flag lists all builtin + config-registered markers
- --fixtures flag lists all builtin + conftest fixtures with scope
- --collect-only tree view grouped by <Module>/<Class>/<Function>

133 tests pass, zero clippy warnings, clean fmt.

Generated with AI